### PR TITLE
Make TestQuickly work again now that Debug commands are in an extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-A trivial Brackets extension that adds a "Quick Tests" menu item (with ctrl/cmd-P shortcut)
+A trivial Brackets extension that adds a shortcut Cmd/Ctrl-P
 for running tests that are referred to by the current file.
 
 To tell the extension which tests should be run, add a specially formatted comment to the file.

--- a/main.js
+++ b/main.js
@@ -27,9 +27,8 @@
 define(function (require, exports, module) {
     "use strict";
     var CommandManager       = brackets.getModule("command/CommandManager"),
-        Menus                = brackets.getModule("command/Menus"),
-        DocumentManager      = brackets.getModule("document/DocumentManager"),
-        DebugCommandHandlers = brackets.getModule("debug/DebugCommandHandlers");
+        KeyBindingManager    = brackets.getModule("command/KeyBindingManager"),
+        DocumentManager      = brackets.getModule("document/DocumentManager");
     
     var unittestRegex = /\/\*\s*unittests:\s*([\w\s]+)\s*\*\//;
     
@@ -38,13 +37,13 @@ define(function (require, exports, module) {
         var text = doc.getText();
         var match = unittestRegex.exec(text);
         var suite = match !== null ? match[1] : "";
-        DebugCommandHandlers._runUnitTests(suite);
+        CommandManager.execute("debug.runUnitTests", suite); // hard-coded string from DebugCommands extension
     }
     
     function init() {
-        var command = CommandManager.register("Quick Tests", "dangoor.testquickly.quicktests", runTests);
-        var debugMenu = Menus.getMenu(Menus.AppMenuBar.DEBUG_MENU);
-        debugMenu.addMenuItem(command, "Ctrl-P", Menus.AFTER, "debug.runUnitTests");
+        var commandId = "dangoor.testquickly.quicktests",
+            command = CommandManager.register("Quick Tests", commandId, runTests);
+        KeyBindingManager.addBinding(commandId, { key: "Cmd-P" });
     }
     
     init();


### PR DESCRIPTION
Since the Debug commands have been moved into an extension, we can't directly call `_runTestSuite()`, and we can't actually add to the Debug menu since it might not have been created before we're loaded.

We really need the whole extension cross-dependency thing solved :), but until then, this just calls the command by string ID, and just adds the Cmd-P keybinding without trying to add it to a menu.
